### PR TITLE
Changing the defaults for correlation computation.

### DIFF
--- a/XTRegisterSameChannel.py
+++ b/XTRegisterSameChannel.py
@@ -651,6 +651,7 @@ class RegisterSameChannelDialog(ieb.ImarisExtensionBase):
             self.correlation_cb_layout.addWidget(
                 QCheckBox(self.registration_channel_combo.itemText(i))
             )
+            self.correlation_cb_layout.itemAt(i).widget().setChecked(True)
 
     def __compute_correlations(self):
         self.restart_button.setEnabled(False)


### PR DESCRIPTION
In the last optional step, computing correlation before and after
registration. Checkboxes for all shared channels will by default
be on. This is likely the more common user desired setting
(feedback from Colin Chu).