### PR TITLE
Adding missing support for reading null bytes attribute.

### DIFF
--- a/test/data/image_2D_three_channels_one_resolution_four_timepoints.ims
+++ b/test/data/image_2D_three_channels_one_resolution_four_timepoints.ims
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d02ce840d1ae283ac6ccfce91782f01442303320f7d8feb4673404cf65b3d7d
+oid sha256:bd282eca91e54e4ba3134c297217030c767619456c8c6e7d21de6bdfe26ed55e
 size 10125867

--- a/test/test_sio.py
+++ b/test/test_sio.py
@@ -51,7 +51,7 @@ class TestIO:
             ),
             (
                 "image_2D_three_channels_one_resolution_four_timepoints.ims",
-                "d5c3cb2c39772fa00002a00a26e9a00e",
+                "59b218cd6134dc616e631a778bcc92ae",
             ),
             (
                 "image_3D_six_channels_four_resolutions_one_timepoint.ims",
@@ -303,19 +303,19 @@ class TestIO:
                     None,
                     (
                         "307a1361d5a7544078cd1ca365131ea9",
-                        "783b45321e1efa291fc726328d60db36",
+                        "0db4a6c2b43dd600e1ed3da9d1a5ea4d",
                     ),
                     (
                         "307a1361d5a7544078cd1ca365131ea9",
-                        "783b45321e1efa291fc726328d60db36",
+                        "0db4a6c2b43dd600e1ed3da9d1a5ea4d",
                     ),
                     (
                         "7b7b8ae148c50476b2fb624ad02040e1",
-                        "ee35a4c0160bd817e3c81d63d618abdd",
+                        "696ba910b4d6fd26ad2ba63468fe4f1b",
                     ),
                     (
                         "7b7b8ae148c50476b2fb624ad02040e1",
-                        "ee35a4c0160bd817e3c81d63d618abdd",
+                        "696ba910b4d6fd26ad2ba63468fe4f1b",
                     ),
                 ],
             ),
@@ -499,7 +499,7 @@ class TestIO:
                     None,
                     (
                         "76266ec9b4f72ef86d314455c079cd09",
-                        "3b5effec60d16fd16f10bb84861b4e69",
+                        "bc72611e8a40cabfcda0ed4750aca8e8",
                     ),
                 ],
             ),


### PR DESCRIPTION
Reading and writing of a null bytes attribute ('\x00') wasn't working
correctly. In our case, when the channel name or description didn't
contain anything it caused an exception. This commit addresses the issue.
See also h5py documentation on "Storing strings".