### PR TITLE
Close all windows when the main application window is closed.

### DIFF
--- a/XTChannelArithmetic.py
+++ b/XTChannelArithmetic.py
@@ -251,6 +251,14 @@ class ChannelArithmeticDialog(ieb.ImarisExtensionBase):
 
         self.status_bar = self.statusBar()
 
+    def closeEvent(self, event):
+        """
+        Override the closeEvent method so that clicking the 'x' button also
+        closes all of the dialogs.
+        """
+        self.help_dialog.close()
+        event.accept()
+
     def __create_arithmetic_widget(self):
         wid = QWidget(self)
         arithmetic_layout = QVBoxLayout()

--- a/XTConfigureChannelSettings.py
+++ b/XTConfigureChannelSettings.py
@@ -172,6 +172,14 @@ class ConfigureChannelSettingsDialog(ieb.ImarisExtensionBase):
         self.stack.addWidget(apply_widget)
         layout.addWidget(self.stack)
 
+    def closeEvent(self, event):
+        """
+        Override the closeEvent method so that clicking the 'x' button also
+        closes all of the dialogs.
+        """
+        self.help_dialog.close()
+        event.accept()
+
     def __show_stacked_widget(self, i):
         self.stack.setCurrentIndex(i)
 

--- a/XTExportChannelSettings.py
+++ b/XTExportChannelSettings.py
@@ -155,6 +155,14 @@ class ExportChannelSettingsDialog(ieb.ImarisExtensionBase):
         button.clicked.connect(self.__export_channel_settings)
         layout.addWidget(button)
 
+    def closeEvent(self, event):
+        """
+        Override the closeEvent method so that clicking the 'x' button also
+        closes all of the dialogs.
+        """
+        self.help_dialog.close()
+        event.accept()
+
     def __browse_callback(self):
         file_name, _ = QFileDialog.getOpenFileName(
             self, "QFileDialog.getOpenFileName()", "", "Imaris (*.ims);;All Files (*)"

--- a/XTRegisterSameChannel.py
+++ b/XTRegisterSameChannel.py
@@ -276,6 +276,15 @@ class RegisterSameChannelDialog(ieb.ImarisExtensionBase):
 
         self.status_bar = self.statusBar()
 
+    def closeEvent(self, event):
+        """
+        Override the closeEvent method so that clicking the 'x' button also
+        closes all of the dialogs.
+        """
+        self.help_dialog.close()
+        self.advanced_settings_widget.close()
+        event.accept()
+
     def __create_advanced_settings_widget(self):
         wid = QWidget()
         wid.setWindowTitle("Advanced Settings")


### PR DESCRIPTION
When our extension application is closed via the “X” button we close
all the dialogs associated with that program. Previously the user had
to manually close each of them.