### PR TITLE
Add quotation marks around the path to the activate script.

### DIFF
--- a/run_extensions.bat
+++ b/run_extensions.bat
@@ -1,8 +1,10 @@
-REM provide the full path to the activate batch script
-REM need to use 'call' because this is a batch file invoked
+REM Provide the full path to the activate batch script.
+REM Path is in quotation marks to accommodate for spaces in
+REM directory names.
+REM Need to use 'call' because this is a batch file invoked
 REM from this batch file. Need to activate explicitly as this
 REM places the appropriate DLLs in the path.
 
-call F:\toolkits\Anaconda3\Scripts\activate imaris
+call "F:\toolkits\Anaconda3\Scripts\activate" imaris
 python ExtensionDriver.py
 pause


### PR DESCRIPTION
Quotation marks are required to accommodate for spaces in directory names (a common occurrence on windows).

Co-authored-by: Bruno Charbit <b.charbit@ucl.ac.uk>