### PR TITLE
Pinning SimpleITK version to 2.2.1.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7.0 #Python version supported by imaris
   - pip
   - pip:
-    - SimpleITK >= 2.0.0
+    - SimpleITK == 2.2.1
     - numpy
     - pandas
     - h5py>=2.10.0


### PR DESCRIPTION
Pinning SimpleITK version to the last version which was released with binaries for Python 3.7.0 which is required by Imaris. Python version 3.7.0 reached end of life in June 27 2023, so newer versions of SimpleITK do not have binaries for 3.7.0 and we don't want pip to try and install from source.

Possibly install in stand-alone mode which doesn't depend on the Python version required by Imaris. In this case we can use the latest version of SimpleITK and just change the Python version to something later than 3.7.0 (as of this writing 3.11 is recommended).