### PR TITLE
Change in Python 3.10.11 causes import error.

### DIFF
--- a/docs/generate_documentation.py
+++ b/docs/generate_documentation.py
@@ -2,7 +2,7 @@ import os
 import sys
 import tempfile
 import inspect
-import importlib
+import importlib.util
 
 css_file_name = "midnight-green.css"
 file_dir_path = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Change in 3.10.11 requires "import importlib.util". Using "import importlib" and then referring to the util module no longer works (AttributeError: module 'importlib' has no attribute 'util').