### PR TITLE
Updating the installation files.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7.0 #Python version supported by imaris
   - pip
   - pip:
-    - SimpleITK == 2.2.1
+    - SimpleITK == 2.2.1 #last SimpleITK version providing Python 3.7 binaries
     - numpy
     - pandas
     - h5py>=2.10.0

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7.0 #Python version supported by imaris
   - pip
   - pip:
-    - SimpleITK == 2.2.1
+    - SimpleITK == 2.2.1 #last SimpleITK version providing Python 3.7 binaries
     - numpy
     - pandas
     - h5py>=2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 #
-# Requirements file for SimpleITK Imaris Python 3.7 extensions.
+# Requirements file for SimpleITK Imaris extensions.
+# Python 3.7.0 is the Python version supported by imaris. SimpleITK version
+# 2.2.1 is the last version providing binaries for 3.7.0.
 #
-SimpleITK == 2.2.1
+SimpleITK == 2.2.1; python_version == '3.7'
 numpy
 pandas
 h5py>=2.10.0


### PR DESCRIPTION
Update the documentation in the conda files and change the requirements file so that if installed for Python 3.7 the last version of SimpleITK that provided binaries for that Python version is installed, otherwise the newest version is installed.