### PR TITLE
Correct the license listed on Zenodo.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,9 +8,7 @@
         "Image Analysis",
         "SimpleITK"
     ],
-    "license": {
-        "id": "CC-BY-4.0"
-    },
+    "license": "Apache-2.0",
     "title": "SimpleITK Imaris Extensions",
     "upload_type": "software",
     "creators": [


### PR DESCRIPTION
The license was mistakenly listed as CC-BY-4.0 and should have been Apache 2.0, this commit corrects it.