### PR TITLE
Adding dependabot updates for github actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
Enable dependabot to automatically create pull requests to keep the GitHub action versions up to date.