### PR TITLE
Removing the defaults channel from the configuration files.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,5 @@
 name: imaris
 
-channels:
-  - defaults
 dependencies:
   - python=3.7.0 #Python version supported by imaris
   - pip

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,7 +1,5 @@
 name: imaris_dev
 
-channels:
-  - defaults
 dependencies:
   - python=3.7.0 #Python version supported by imaris
   - pip


### PR DESCRIPTION
The default channel wasn't used, so no need to list it. All packages installed from PyPI.