### PR TITLE
Update CI configuration.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,12 +52,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, "3.10"]
-        exclude: # macos-latest, 14, does not have Python 3.7, so workaround for now
+        exclude: # macos-latest and ubuntu-latest, do not have Python 3.7, so workaround for now
           - python-version: "3.7"
             os: macos-latest
-        include: # Run Python 3.7 on older macos
+          - python-version: "3.7"
+            os: ubuntu-latest
+        include: # Run Python 3.7 on older macos and ubuntu
           - python-version: "3.7"
             os: macos-13
+          - python-version: "3.7"
+            os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
ubuntu-latest no longer supports Python 3.7. Instead run on older ubuntu that is still available.